### PR TITLE
Fixed mouse reporting escape sequences

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ record_events.bat
 /examples/dev_test.rs
 tarpaulin-report.html
 *.profraw
+/.idea

--- a/appcui/src/backend/crossterm/implementation.rs
+++ b/appcui/src/backend/crossterm/implementation.rs
@@ -4,7 +4,7 @@ use crate::{
     graphics::{CharFlags, Color, Size, Surface},
     system::{Error, SystemEvent},
 };
-use crossterm::event::EnableMouseCapture;
+use crossterm::event::{DisableMouseCapture, EnableMouseCapture};
 use crossterm::{
     cursor::{Hide, MoveTo, Show},
     execute, queue,
@@ -243,6 +243,7 @@ impl Backend for CrossTerm {
     }
 
     fn on_close(&mut self) {
+        let _ = execute!(stdout(), DisableMouseCapture);
         let _ = execute!(stdout(), LeaveAlternateScreen, Show, ResetColor);
         let _ = disable_raw_mode();
     }

--- a/appcui/src/backend/ncurses/implementation.rs
+++ b/appcui/src/backend/ncurses/implementation.rs
@@ -42,7 +42,7 @@ impl NcursesTerminal {
             (ncursesapi::constants::ALL_MOUSE_EVENTS as mmask_t | ncursesapi::constants::REPORT_MOUSE_POSITION as mmask_t) as mmask_t,
             None,
         );
-        println!("\x1B[?1003h");
+        println!("\x1b[?1000h\x1b[?1002h\x1b[?1003h\x1b[?1006h");
         ncursesapi::lib::ncurses_mouseinterval(0);
         ncursesapi::lib::ncurses_set_escdelay(0);
 
@@ -165,6 +165,10 @@ impl Backend for NcursesTerminal {
         ncursesapi::lib::ncurses_wrefresh(self.win);
     }
 
+    fn on_resize(&mut self, new_size: Size) {
+        self.size = new_size;
+    }
+
     fn size(&self) -> Size {
         self.size
     }
@@ -184,11 +188,11 @@ impl Backend for NcursesTerminal {
         ctx.get_contents().is_ok()
     }
 
-    fn on_resize(&mut self, new_size: Size) {
-        self.size = new_size;
-    }
-
     fn is_single_threaded(&self) -> bool {
         false
+    }
+
+    fn on_close(&mut self) {
+        println!("\x1b[?1000l\x1b[?1002l\x1b[?1003l\x1b[?1006l")
     }
 }

--- a/appcui/src/backend/termios/implementation.rs
+++ b/appcui/src/backend/termios/implementation.rs
@@ -79,8 +79,6 @@ impl TermiosTerminal {
 
         t.ansi_buffer.clear();
         t.ansi_buffer.enable_mouse_events();
-        let _ = std::io::stdout().write_all(t.ansi_buffer.text().as_bytes());
-        let _ = std::io::stdout().flush();
 
         Input::new().start(sender.clone());
         SizeReader::new(get_resize_notification().clone()).start(sender);
@@ -96,13 +94,14 @@ impl Backend for TermiosTerminal {
         let _ = std::io::stdout().flush();
     }
 
+    fn on_resize(&mut self, new_size: Size) {
+        self.size = new_size;
+    }
+
     fn size(&self) -> Size {
         self.size
     }
 
-    fn query_system_event(&mut self) -> Option<SystemEvent> {
-        None
-    }
     fn clipboard_text(&self) -> Option<String> {
         let mut ctx: ClipboardContext = ClipboardContext::new().ok()?;
         ctx.get_contents().ok()
@@ -118,22 +117,17 @@ impl Backend for TermiosTerminal {
         ctx.get_contents().is_ok()
     }
 
-    fn on_resize(&mut self, new_size: Size) {
-        self.size = new_size;
-    }
-
-    fn on_close(&mut self) {
-        self.ansi_buffer.clear();
-        self.ansi_buffer.disable_mouse_events();
-        let _ = std::io::stdout().write_all(self.ansi_buffer.text().as_bytes());
-        let _ = std::io::stdout().flush();
-        self.orig_termios.restore();
+    fn query_system_event(&mut self) -> Option<SystemEvent> {
+        None
     }
 
     fn is_single_threaded(&self) -> bool {
         false
     }
-}
 
-#[derive(Debug, Default, PartialEq, Eq)]
-pub struct UnsupportedCode([u8; 5]);
+    fn on_close(&mut self) {
+        self.ansi_buffer.clear();
+        self.ansi_buffer.disable_mouse_events();
+        self.orig_termios.restore();
+    }
+}

--- a/appcui/src/backend/utils/ansi_formatter.rs
+++ b/appcui/src/backend/utils/ansi_formatter.rs
@@ -1,3 +1,4 @@
+use std::io::Write;
 use crate::graphics::{CharFlags, Color, Point, Surface};
 use EnumBitFlags::EnumBitFlags;
 
@@ -39,13 +40,15 @@ impl AnsiFormatter {
     pub(crate) fn write_string(&mut self, s: &str) {
         self.text.push_str(s);
     }
-    #[allow(dead_code)]
+
     pub(crate) fn enable_mouse_events(&mut self) {
-        self.text.push_str("\x1b[?1003h");
+        std::io::stdout().write_all(b"\x1b[?1000h\x1b[?1002h\x1b[?1003h\x1b[?1006h").unwrap();
+        std::io::stdout().flush().unwrap();
     }
-    #[allow(dead_code)]
+
     pub(crate) fn disable_mouse_events(&mut self) {
-        self.text.push_str("\x1b[?1003l");
+        std::io::stdout().write_all(b"\x1b[?1000l\x1b[?1002l\x1b[?1003l\x1b[?1006l").unwrap();
+        std::io::stdout().flush().unwrap();
     }
     #[inline(always)]
     pub(crate) fn set_foreground_color(&mut self, color: Color) {

--- a/appcui/src/backend/utils/tests.rs
+++ b/appcui/src/backend/utils/tests.rs
@@ -10,7 +10,7 @@ fn check_ansi_methods() {
     assert_eq!(a.text(),"\x1b[?1003h");
     a.clear();
     a.disable_mouse_events();
-    assert_eq!(a.text(),"\x1b[?1003l");
+    assert_eq!(a.text(),"\x1b[?1000l\x1b[?1002l\x1b[?1003l\x1b[?1006l");
     a.clear();
     a.write_char('a');
     assert_eq!(a.text(),"a");


### PR DESCRIPTION
Hello,

This PR fixes mouse reporting escape sequences on Linux for the following backends:
- Ncurses
- Crossterm
- Termios (cannot get it to work but it is close..., so I left what I improved)

Here is an example of the problem after closing any AppCUI-rs app, when moving the mouse over the terminal:
<img width="927" height="95" alt="image" src="https://github.com/user-attachments/assets/7b199845-d592-40c0-b353-fc242d0c6d97" />

After this fix, this stops happening and no escape sequence gets printed.

Have a great day